### PR TITLE
Add config to allow routes without .html extension.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,8 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     unoptimized: true,
-  }
+  },
+  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    unoptimized: true,
+    unoptimized: true
   },
   trailingSlash: true
 }

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  trailingSlash: true,
+  trailingSlash: true
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Ticket Description
No ticket for this is. Problem was observed in production.


## Description of Changes
Trying a config to enable routes without .html extension, per this DO forum suggestion https://www.digitalocean.com/community/questions/next-js-static-site-requires-html-extension-in-url-for-dynamic-routes.

## Before and After for UI Updates
Only visible different is the URL structure not requiring the .html extension.
