### PR TITLE
Keep incubating GIEE and GLQF sections out of search results

### DIFF
--- a/components/GieeLayout.tsx
+++ b/components/GieeLayout.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from "react";
+import Head from "next/head";
 import AppHead from "./AppHead";
 import GieeNavbar from "./GieeNavbar";
 import GieeFooter from "./GieeFooter";
+import { INDEXABLE } from "../constants/seo";
 
 interface GieeLayoutProps {
   children: ReactNode;
@@ -11,6 +13,11 @@ export default function GieeLayout({ children }: GieeLayoutProps) {
   return (
     <>
       <AppHead />
+      {!INDEXABLE.giee && (
+        <Head>
+          <meta name="robots" content="noindex, nofollow" />
+        </Head>
+      )}
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>

--- a/components/GlqfLayout.tsx
+++ b/components/GlqfLayout.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from "react";
+import Head from "next/head";
 import AppHead from "./AppHead";
 import GlqfNavbar from "./GlqfNavbar";
 import GlqfFooter from "./GlqfFooter";
+import { INDEXABLE } from "../constants/seo";
 
 interface GlqfLayoutProps {
   children: ReactNode;
@@ -11,6 +13,11 @@ export default function GlqfLayout({ children }: GlqfLayoutProps) {
   return (
     <>
       <AppHead />
+      {!INDEXABLE.glqf && (
+        <Head>
+          <meta name="robots" content="noindex, nofollow" />
+        </Head>
+      )}
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>

--- a/constants/seo.js
+++ b/constants/seo.js
@@ -1,0 +1,10 @@
+// Search-engine indexing toggles for incubating sections.
+//
+// While a section is still in progress we keep it out of search results with a
+// `noindex` robots meta tag, rendered by that section's layout component. When a
+// section is ready to launch publicly, flip its flag to `true` (or delete the
+// entry) and the noindex tag is no longer emitted.
+export const INDEXABLE = {
+  giee: false,
+  glqf: false,
+};


### PR DESCRIPTION
## What

Adds a `noindex, nofollow` robots meta tag to the GIEE and GLQF sections so these in-progress pages aren't indexed by search engines, with an easy toggle to enable indexing per-section when each is ready to launch.

## How

- **`constants/seo.js`** — single source-of-truth toggle: `INDEXABLE = { giee: false, glqf: false }`.
- **`GieeLayout` / `GlqfLayout`** — emit `<meta name="robots" content="noindex, nofollow">` while the section's flag is `false`. Because `/giee`, `/glqf`, and the `/glqf/[slug]` detail pages all route through these layouts, coverage is automatic.

A `noindex` meta tag is the authoritative "don't index" signal — stronger than a `robots.txt` `Disallow`, which only blocks crawling and can still leave URLs showing in results.

## Going live later

Flip the relevant flag to `true` in `constants/seo.js` (sections are independent):

\`\`\`js
export const INDEXABLE = { giee: true, glqf: false }; // launch GIEE, keep GLQF hidden
\`\`\`

## Verification

Confirmed against the production build output that the tag renders on `/giee`, `/glqf`, and `/glqf/integration`, and is absent on `/`. `npm run build` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)