### PR TITLE
Add GIEE page with brand palette and accessibility tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
+          GLQF_BASIC_AUTH_USER: ${{ secrets.GLQF_BASIC_AUTH_USER }}
+          GLQF_BASIC_AUTH_PASS: ${{ secrets.GLQF_BASIC_AUTH_PASS }}
+          GIEE_BASIC_AUTH_USER: ${{ secrets.GIEE_BASIC_AUTH_USER }}
+          GIEE_BASIC_AUTH_PASS: ${{ secrets.GIEE_BASIC_AUTH_PASS }}
       # - name: Build and export with Next.js
       #   run: npm run export
       #   env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,6 @@ jobs:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
-          GLQF_BASIC_AUTH_USER: ${{ secrets.GLQF_BASIC_AUTH_USER }}
-          GLQF_BASIC_AUTH_PASS: ${{ secrets.GLQF_BASIC_AUTH_PASS }}
-          GIEE_BASIC_AUTH_USER: ${{ secrets.GIEE_BASIC_AUTH_USER }}
-          GIEE_BASIC_AUTH_PASS: ${{ secrets.GIEE_BASIC_AUTH_PASS }}
       # - name: Build and export with Next.js
       #   run: npm run export
       #   env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-SPEC (Sustainable Progress & Equality Collective) frontend — a Next.js 14 website using the **Pages Router** (not App Router). TypeScript with some plain JS files. Node 18.18.2 (pinned).
+SPEC (Sustainable Progress & Equality Collective) frontend — a Next.js 16 website using the **Pages Router** (not App Router). TypeScript with some plain JS files. (Note: `.nvmrc` pins Node 18.18.2, but `package.json` `engines` require `>=20.9.0` and CI / the DigitalOcean buildpack build on Node 22 — treat 20.9+ as the real floor.)
 
 ## Commands
 
@@ -19,11 +19,24 @@ npm run test -- path/to/test.tsx     # Single test file
 
 ## Environment Variables
 
-Copy `.env.sample` to `.env.local`. The sample only includes Nodemailer credentials. You also need:
+Copy `.env.sample` to `.env.local` for local dev. The sample only includes Nodemailer credentials; the full set used by the app:
 
 - `CONTENTFUL_SPACE_ID` — Contentful CMS space ID
 - `CONTENTFUL_ACCESS_TOKEN` — Contentful delivery API token
+- `NODE_MAILER_EMAIL` / `NODE_MAILER_PASSWORD` — Nodemailer/Gmail SMTP for the contact form
 - `NEXT_PUBLIC_API_URL` — Optional; overrides contact form API URL (defaults to `http://localhost:3000/api/contact`)
+- `GLQF_BASIC_AUTH_USER` / `GLQF_BASIC_AUTH_PASS` — Basic-auth gate for `/glqf`
+- `GIEE_BASIC_AUTH_USER` / `GIEE_BASIC_AUTH_PASS` — Basic-auth gate for `/giee`
+
+**Runtime, not build:** every variable above is read at **runtime** — by the `proxy.ts` middleware (basic auth) and `getServerSideProps` (Contentful) — *not* inlined at build time. In production they must be set in the **DigitalOcean App Platform** environment (see Deployment), **not** in GitHub Actions. If a basic-auth pair is unset, that page returns `503 Basic auth not configured`.
+
+## Deployment
+
+Hosted on **DigitalOcean App Platform** (app name `spec-frontend`). The app spec is committed at `.do/deploy-template.yml` — a single `server` service on the Ubuntu-22 buildpack stack. The buildpack runs `npm run build` then `npm start` (`next start -H 0.0.0.0 -p ${PORT:-8080}`), i.e. a long-running Node server — *not* a static export and *not* Vercel.
+
+- **Production env vars** (Contentful, Nodemailer, `GLQF_/GIEE_BASIC_AUTH_*`) are configured in the DigitalOcean dashboard: App Platform → `spec-frontend` → Settings → the `server` component → **Environment Variables** (mark secrets as encrypted), then redeploy. They are **not** in the repo and **not** in GitHub Actions.
+- **GitHub Actions does not deploy.** The only workflows are `build.yml` (compiles, with Contentful build-env) and `lint.yml`; neither ships to production. DigitalOcean redeploys on push to the deploy branch via its own GitHub integration.
+- **To add a new gated page or secret:** read the new `process.env.*` var in `proxy.ts`, then add the value in the DO dashboard for the `server` component.
 
 ## Architecture
 
@@ -67,7 +80,7 @@ Contact form uses **Formik + Yup** for form state and validation (`components/Co
 
 - Components are TypeScript (`.tsx`); some utilities and constants are plain JS
 - No path aliases — use relative imports
-- `middleware.ts` redirects `www.` to apex domain
+- `proxy.ts` (Next 16's renamed middleware — runs at runtime) redirects `www.` to the apex domain and gates `/glqf` and `/giee` behind HTTP basic auth
 - `next.config.js` has `trailingSlash: true` and `images: { unoptimized: true }`
 - ESLint config is minimal: just `next/core-web-vitals`
 - CI runs build and lint on every push/PR (GitHub Actions) but does **not** run tests

--- a/README.md
+++ b/README.md
@@ -45,4 +45,22 @@ To copy over env variables needed for email functionality
 cp .env.sample .env.local
 ```
 
-Fill in the variables as needed
+Fill in the variables as needed.
+
+Beyond the Nodemailer credentials in `.env.sample`, the app also reads:
+
+- `CONTENTFUL_SPACE_ID` / `CONTENTFUL_ACCESS_TOKEN` — Contentful CMS (homepage hero)
+- `GLQF_BASIC_AUTH_USER` / `GLQF_BASIC_AUTH_PASS` — basic-auth gate for `/glqf`
+- `GIEE_BASIC_AUTH_USER` / `GIEE_BASIC_AUTH_PASS` — basic-auth gate for `/giee`
+
+These are all read at **runtime** (by `proxy.ts` and `getServerSideProps`), so in production they must be set on the host (see Deployment), not baked into the build.
+
+## Deployment
+
+Deployed on **DigitalOcean App Platform** (app `spec-frontend`). The app spec is committed at `.do/deploy-template.yml` (single `server` service, Ubuntu-22 buildpack); the buildpack runs `npm run build` then `npm start`. DigitalOcean redeploys automatically from GitHub — the repo's GitHub Actions (`build.yml`, `lint.yml`) only build and lint, they do **not** deploy.
+
+Production environment variables (Contentful, Nodemailer, and the `GLQF_/GIEE_BASIC_AUTH_*` gates) are managed in the DigitalOcean dashboard:
+
+> App Platform → `spec-frontend` → Settings → `server` component → Environment Variables (mark secrets as encrypted), then redeploy.
+
+If a basic-auth pair is missing, that page returns `503 Basic auth not configured`.

--- a/__tests__/a11y/accessibility.test.tsx
+++ b/__tests__/a11y/accessibility.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { axe } from "jest-axe";
+
+import Home from "../../pages/index";
+import OurTeam from "../../pages/ourTeam";
+import GieePage from "../../pages/giee";
+import GlqfPage from "../../pages/glqf";
+
+// Renders each page that mounts without server-side props and asserts that
+// axe-core finds no accessibility violations in the rendered markup.
+const pages: [string, () => JSX.Element][] = [
+  ["index", Home],
+  ["ourTeam", OurTeam],
+  ["giee", GieePage],
+  ["glqf", GlqfPage],
+];
+
+describe("accessibility (jest-axe)", () => {
+  it.each(pages)("%s page has no axe violations", async (_name, Page) => {
+    const { container } = render(<Page />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/GieeFooter.tsx
+++ b/components/GieeFooter.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+
+export default function GieeFooter() {
+  return (
+    <footer className="border-t border-giee-line bg-giee-paper">
+      <div className="mx-auto max-w-6xl px-6 py-12 md:px-10 md:py-16">
+        <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-md">
+            <p className="font-dmserif text-2xl leading-none text-giee-ink">
+              GIEE
+            </p>
+            <p className="mt-3 font-montserrat text-sm leading-relaxed text-giee-slate">
+              The Global Inclusive Education Ecosystem — designing the global
+              benchmarks, policies, and guardrails that keep AI an instrument
+              for collective empowerment and educational trust.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 md:items-end">
+            <a
+              href="https://specollective.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-montserrat text-xs uppercase tracking-[0.22em] text-giee-ink-soft hover:text-giee-ink"
+            >
+              An initiative of SPEC ↗
+            </a>
+            <Link
+              href="/contact"
+              className="font-montserrat text-sm text-giee-ink-soft hover:text-giee-ink"
+            >
+              Contact
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-10 border-t border-giee-line pt-6">
+          <p className="font-montserrat text-xs text-giee-slate">
+            © {new Date().getFullYear()} Sustainable Progress &amp; Equality
+            Collective. In collaboration with GOER and the UN-Geneva Forum.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/GieeFooter.tsx
+++ b/components/GieeFooter.tsx
@@ -21,7 +21,7 @@ export default function GieeFooter() {
               href="https://specollective.org"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-giee-sans text-sm tracking-[0.12em] text-giee-slate [font-variant:small-caps] hover:text-giee-ink"
+              className="font-giee-sans text-sm tracking-[0.12em] text-giee-slate hover:text-giee-ink"
             >
               An initiative of SPEC ↗
             </a>
@@ -36,8 +36,7 @@ export default function GieeFooter() {
 
         <div className="mt-10 border-t border-giee-line pt-6">
           <p className="font-giee-sans text-xs text-giee-slate">
-            © {new Date().getFullYear()} Sustainable Progress &amp; Equality
-            Collective. In collaboration with GOER and the UN-Geneva Forum.
+            © 2026 Sustainable Progress &amp; Equality Collective.
           </p>
         </div>
       </div>

--- a/components/GieeFooter.tsx
+++ b/components/GieeFooter.tsx
@@ -6,10 +6,10 @@ export default function GieeFooter() {
       <div className="mx-auto max-w-6xl px-6 py-12 md:px-10 md:py-16">
         <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
           <div className="max-w-md">
-            <p className="font-dmserif text-2xl leading-none text-giee-ink">
+            <p className="font-giee-serif text-2xl leading-none text-giee-ink">
               GIEE
             </p>
-            <p className="mt-3 font-montserrat text-sm leading-relaxed text-giee-slate">
+            <p className="mt-3 font-giee-sans text-sm leading-relaxed text-giee-slate">
               The Global Inclusive Education Ecosystem — designing the global
               benchmarks, policies, and guardrails that keep AI an instrument
               for collective empowerment and educational trust.
@@ -21,13 +21,13 @@ export default function GieeFooter() {
               href="https://specollective.org"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-montserrat text-xs uppercase tracking-[0.22em] text-giee-ink-soft hover:text-giee-ink"
+              className="font-giee-sans text-sm tracking-[0.12em] text-giee-slate [font-variant:small-caps] hover:text-giee-ink"
             >
               An initiative of SPEC ↗
             </a>
             <Link
               href="/contact"
-              className="font-montserrat text-sm text-giee-ink-soft hover:text-giee-ink"
+              className="font-giee-sans text-sm text-giee-ink-soft hover:text-giee-ink"
             >
               Contact
             </Link>
@@ -35,7 +35,7 @@ export default function GieeFooter() {
         </div>
 
         <div className="mt-10 border-t border-giee-line pt-6">
-          <p className="font-montserrat text-xs text-giee-slate">
+          <p className="font-giee-sans text-xs text-giee-slate">
             © {new Date().getFullYear()} Sustainable Progress &amp; Equality
             Collective. In collaboration with GOER and the UN-Geneva Forum.
           </p>

--- a/components/GieeLayout.tsx
+++ b/components/GieeLayout.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from "react";
+import Head from "next/head";
 import AppHead from "./AppHead";
 import GieeNavbar from "./GieeNavbar";
 import GieeFooter from "./GieeFooter";
+import { INDEXABLE } from "../constants/seo";
 
 interface GieeLayoutProps {
   children: ReactNode;
@@ -11,6 +13,11 @@ export default function GieeLayout({ children }: GieeLayoutProps) {
   return (
     <>
       <AppHead />
+      {!INDEXABLE.giee && (
+        <Head>
+          <meta name="robots" content="noindex, nofollow" />
+        </Head>
+      )}
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>

--- a/components/GieeLayout.tsx
+++ b/components/GieeLayout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import AppHead from "./AppHead";
+import GieeNavbar from "./GieeNavbar";
+import GieeFooter from "./GieeFooter";
+
+interface GieeLayoutProps {
+  children: ReactNode;
+}
+
+export default function GieeLayout({ children }: GieeLayoutProps) {
+  return (
+    <>
+      <AppHead />
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
+      <div className="bg-giee-paper text-giee-ink">
+        <GieeNavbar />
+        <main id="main-content">{children}</main>
+        <GieeFooter />
+      </div>
+    </>
+  );
+}

--- a/components/GieeNavbar.tsx
+++ b/components/GieeNavbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 
 const NAV_LINKS = [
@@ -7,6 +7,149 @@ const NAV_LINKS = [
   { href: "/giee#initiatives", label: "Initiatives" },
   { href: "/giee#engage", label: "Get Involved" },
 ];
+
+// Supported languages for the GIEE site. Selection is presentational only for
+// now — wiring the chosen locale into actual content translation lands in a
+// separate internationalization PR.
+const LANGUAGES = [
+  { code: "en", label: "English", short: "EN" },
+  { code: "es", label: "Español", short: "ES" },
+  { code: "fr", label: "Français", short: "FR" },
+] as const;
+
+type LanguageCode = (typeof LANGUAGES)[number]["code"];
+
+function GlobeIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18" />
+      <path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+// Desktop disclosure dropdown. Implemented as a button-triggered panel of
+// buttons (rather than a half-finished listbox) so every option is natively
+// focusable and operable by keyboard.
+function LanguageMenu({
+  value,
+  onChange,
+}: {
+  value: LanguageCode;
+  onChange: (code: LanguageCode) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const current = LANGUAGES.find((l) => l.code === value) ?? LANGUAGES[0];
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointer = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls="giee-language-menu"
+        aria-label={`Change language, current language ${current.label}`}
+        className="inline-flex items-center gap-1.5 rounded font-giee-sans text-sm font-medium text-giee-ink-soft transition-colors hover:text-giee-ink"
+      >
+        <GlobeIcon />
+        <span>{current.short}</span>
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          id="giee-language-menu"
+          className="absolute right-0 mt-2 min-w-[10rem] overflow-hidden rounded-md border border-giee-line bg-giee-paper py-1 shadow-lg"
+        >
+          {LANGUAGES.map((lang) => {
+            const selected = lang.code === value;
+            return (
+              <button
+                key={lang.code}
+                type="button"
+                onClick={() => {
+                  onChange(lang.code);
+                  setOpen(false);
+                }}
+                aria-current={selected ? "true" : undefined}
+                className={`flex w-full items-center justify-between gap-3 px-4 py-2 text-left font-giee-sans text-sm transition-colors hover:bg-giee-paper-2 ${
+                  selected
+                    ? "font-semibold text-giee-ink"
+                    : "text-giee-ink-soft"
+                }`}
+              >
+                <span>{lang.label}</span>
+                {selected ? (
+                  <CheckIcon />
+                ) : (
+                  <span className="text-xs uppercase tracking-wide text-giee-ink-soft">
+                    {lang.short}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function Wordmark({ className = "" }: { className?: string }) {
   return (
@@ -24,6 +167,9 @@ function Wordmark({ className = "" }: { className?: string }) {
 
 export default function GieeNavbar() {
   const [open, setOpen] = useState(false);
+  // TODO(i18n): drive this from the active locale / route once translation
+  // wiring lands. For now it is local UI state only.
+  const [language, setLanguage] = useState<LanguageCode>("en");
 
   useEffect(() => {
     if (!open) return;
@@ -40,20 +186,20 @@ export default function GieeNavbar() {
         <Wordmark />
 
         {/* Desktop nav */}
-        <nav
-          aria-label="GIEE navigation"
-          className="hidden items-center gap-8 md:flex"
-        >
-          {NAV_LINKS.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              className="font-giee-sans text-sm font-medium text-giee-ink-soft transition-colors hover:text-giee-ink"
-            >
-              {link.label}
-            </a>
-          ))}
-        </nav>
+        <div className="hidden items-center gap-8 md:flex">
+          <nav aria-label="GIEE navigation" className="flex items-center gap-8">
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="font-giee-sans text-sm font-medium text-giee-ink-soft transition-colors hover:text-giee-ink"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+          <LanguageMenu value={language} onChange={setLanguage} />
+        </div>
 
         {/* Mobile toggle */}
         <button
@@ -111,6 +257,34 @@ export default function GieeNavbar() {
               </li>
             ))}
           </ul>
+
+          {/* Language options */}
+          <div
+            role="group"
+            aria-label="Select language"
+            className="flex items-center gap-2 border-t border-giee-line p-3"
+          >
+            <GlobeIcon />
+            {LANGUAGES.map((lang) => {
+              const selected = lang.code === language;
+              return (
+                <button
+                  key={lang.code}
+                  type="button"
+                  onClick={() => setLanguage(lang.code)}
+                  aria-pressed={selected}
+                  className={`rounded px-3 py-1.5 font-giee-sans text-sm font-medium transition-colors ${
+                    selected
+                      ? "bg-giee-ink text-giee-paper"
+                      : "text-giee-ink-soft hover:bg-giee-paper-2"
+                  }`}
+                >
+                  {lang.short}
+                  <span className="sr-only"> — {lang.label}</span>
+                </button>
+              );
+            })}
+          </div>
         </nav>
       )}
     </header>

--- a/components/GieeNavbar.tsx
+++ b/components/GieeNavbar.tsx
@@ -15,7 +15,7 @@ function Wordmark({ className = "" }: { className?: string }) {
       className={`group inline-flex items-baseline gap-3 ${className}`}
       aria-label="GIEE — Global AI Governance & Inclusive Education Ecosystem, home"
     >
-      <span className="font-dmserif text-2xl leading-none tracking-tight text-giee-ink md:text-3xl">
+      <span className="font-giee-serif text-2xl leading-none tracking-tight text-giee-ink md:text-3xl">
         GIEE
       </span>
     </Link>
@@ -48,7 +48,7 @@ export default function GieeNavbar() {
             <a
               key={link.href}
               href={link.href}
-              className="font-montserrat text-sm font-medium text-giee-ink-soft transition-colors hover:text-giee-ink"
+              className="font-giee-sans text-sm font-medium text-giee-ink-soft transition-colors hover:text-giee-ink"
             >
               {link.label}
             </a>
@@ -104,7 +104,7 @@ export default function GieeNavbar() {
                 <a
                   href={link.href}
                   onClick={() => setOpen(false)}
-                  className="block rounded px-4 py-3 font-montserrat text-base font-medium text-giee-ink hover:bg-giee-paper-2"
+                  className="block rounded px-4 py-3 font-giee-sans text-base font-medium text-giee-ink hover:bg-giee-paper-2"
                 >
                   {link.label}
                 </a>

--- a/components/GieeNavbar.tsx
+++ b/components/GieeNavbar.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const NAV_LINKS = [
+  { href: "/giee#overview", label: "Overview" },
+  { href: "/giee#pillars", label: "Pillars" },
+  { href: "/giee#initiatives", label: "Initiatives" },
+  { href: "/giee#engage", label: "Get Involved" },
+];
+
+function Wordmark({ className = "" }: { className?: string }) {
+  return (
+    <Link
+      href="/giee"
+      className={`group inline-flex items-baseline gap-3 ${className}`}
+      aria-label="GIEE — Global AI Governance & Inclusive Education Ecosystem, home"
+    >
+      <span className="font-dmserif text-2xl leading-none tracking-tight text-giee-ink md:text-3xl">
+        GIEE
+      </span>
+    </Link>
+  );
+}
+
+export default function GieeNavbar() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [open]);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-giee-line bg-giee-paper/95 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6 md:h-20 md:px-10">
+        <Wordmark />
+
+        {/* Desktop nav */}
+        <nav
+          aria-label="GIEE navigation"
+          className="hidden items-center gap-8 md:flex"
+        >
+          {NAV_LINKS.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="font-montserrat text-sm font-medium text-giee-ink-soft transition-colors hover:text-giee-ink"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        {/* Mobile toggle */}
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-label={open ? "Close menu" : "Open menu"}
+          aria-expanded={open}
+          aria-controls="giee-mobile-nav"
+          className="md:hidden inline-flex h-10 w-10 items-center justify-center rounded text-giee-ink"
+        >
+          <span className="sr-only">Menu</span>
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-6 w-6"
+          >
+            {open ? (
+              <>
+                <line x1="6" y1="6" x2="18" y2="18" />
+                <line x1="18" y1="6" x2="6" y2="18" />
+              </>
+            ) : (
+              <>
+                <line x1="4" y1="7" x2="20" y2="7" />
+                <line x1="4" y1="12" x2="20" y2="12" />
+                <line x1="4" y1="17" x2="20" y2="17" />
+              </>
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* Mobile drawer */}
+      {open && (
+        <nav
+          id="giee-mobile-nav"
+          aria-label="GIEE mobile navigation"
+          className="border-t border-giee-line bg-giee-paper md:hidden"
+        >
+          <ul className="flex flex-col p-2">
+            {NAV_LINKS.map((link) => (
+              <li key={link.href}>
+                <a
+                  href={link.href}
+                  onClick={() => setOpen(false)}
+                  className="block rounded px-4 py-3 font-montserrat text-base font-medium text-giee-ink hover:bg-giee-paper-2"
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
+    </header>
+  );
+}

--- a/components/GlqfDiagram.tsx
+++ b/components/GlqfDiagram.tsx
@@ -25,7 +25,7 @@ export const GlqfDiagram: FC<Props> = memo(function GlqfDiagram(props) {
     <svg
       viewBox="-60 0 720 600"
       xmlns="http://www.w3.org/2000/svg"
-      role="img"
+      role="group"
       aria-labelledby="glqf-diagram-title glqf-diagram-desc"
       className={props.className}
     >

--- a/components/GlqfLayout.tsx
+++ b/components/GlqfLayout.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from "react";
+import Head from "next/head";
 import AppHead from "./AppHead";
 import GlqfNavbar from "./GlqfNavbar";
 import GlqfFooter from "./GlqfFooter";
+import { INDEXABLE } from "../constants/seo";
 
 interface GlqfLayoutProps {
   children: ReactNode;
@@ -11,6 +13,11 @@ export default function GlqfLayout({ children }: GlqfLayoutProps) {
   return (
     <>
       <AppHead />
+      {!INDEXABLE.glqf && (
+        <Head>
+          <meta name="robots" content="noindex, nofollow" />
+        </Head>
+      )}
       <a href="#main-content" className="skip-link">
         Skip to main content
       </a>

--- a/constants/seo.js
+++ b/constants/seo.js
@@ -1,0 +1,10 @@
+// Search-engine indexing toggles for incubating sections.
+//
+// While a section is still in progress we keep it out of search results with a
+// `noindex` robots meta tag, rendered by that section's layout component. When a
+// section is ready to launch publicly, flip its flag to `true` (or delete the
+// entry) and the noindex tag is no longer emitted.
+export const INDEXABLE = {
+  giee: false,
+  glqf: false,
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
   // Add more setup options before each test is run
-  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom'

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,6 @@
+// Global Jest setup, loaded via `setupFilesAfterEnv` in jest.config.js.
+import '@testing-library/jest-dom'
+import { toHaveNoViolations } from 'jest-axe'
+
+// Registers the `toHaveNoViolations` matcher for jest-axe accessibility tests.
+expect.extend(toHaveNoViolations)

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
         "yup": "^1.0.2"
       },
       "devDependencies": {
+        "@types/jest-axe": "^3.5.9",
         "autoprefixer": "^10.4.13",
+        "jest-axe": "^10.0.0",
         "postcss": "^8.4.20",
         "tailwindcss": "^3.2.4"
       },
@@ -2863,6 +2865,27 @@
       "dependencies": {
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest-axe": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.9.tgz",
+      "integrity": "sha512-z98CzR0yVDalCEuhGXXO4/zN4HHuSebAukXDjTLJyjEAgoUf1H1i+sr7SUB/mz8CRS/03/XChsx0dcLjHkndoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jest": "*",
+        "axe-core": "^3.5.5"
+      }
+    },
+    "node_modules/@types/jest-axe/node_modules/axe-core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
+      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/jest/node_modules/@jest/schemas": {
@@ -7087,6 +7110,116 @@
           "optional": true
         }
       }
+    },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "yup": "^1.0.2"
   },
   "devDependencies": {
+    "@types/jest-axe": "^3.5.9",
     "autoprefixer": "^10.4.13",
+    "jest-axe": "^10.0.0",
     "postcss": "^8.4.20",
     "tailwindcss": "^3.2.4"
   },

--- a/pages/giee.tsx
+++ b/pages/giee.tsx
@@ -41,7 +41,7 @@ function Eyebrow({
 }) {
   return (
     <h2
-      className={`font-montserrat text-xs font-semibold uppercase tracking-[0.22em] text-giee-accent md:text-sm ${className}`}
+      className={`font-giee-sans text-xs font-semibold uppercase tracking-[0.22em] text-giee-accent md:text-sm ${className}`}
     >
       {children}
     </h2>
@@ -93,12 +93,12 @@ export default function GieePage() {
           className="pointer-events-none absolute inset-x-0 top-0 h-px bg-giee-line"
         />
         <div className="relative mx-auto flex min-h-[82vh] max-w-5xl flex-col items-center justify-center px-6 pb-28 pt-24 text-center md:pt-32">
-          <h1 className="font-dmserif text-4xl leading-[1.05] text-giee-ink md:text-6xl lg:text-7xl">
+          <h1 className="font-giee-serif text-4xl leading-[1.05] text-giee-ink md:text-6xl lg:text-7xl">
             Global AI Governance &amp;
             <br />
             Inclusive Education Ecosystem
           </h1>
-          <p className="mt-8 max-w-2xl font-montserrat text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+          <p className="mt-8 max-w-2xl font-giee-sans text-lg leading-relaxed text-giee-ink-soft md:text-xl">
             The rapid ascension of generative artificial intelligence demands a
             proactive, cross-sector approach to technology governance—one that
             prioritizes human capability, institutional accountability, and
@@ -107,13 +107,13 @@ export default function GieePage() {
           <div className="mt-12 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
             <a
               href="#overview"
-              className="inline-flex w-full items-center justify-center bg-giee-ink px-8 py-4 font-montserrat text-base font-semibold text-giee-paper transition-colors hover:bg-giee-black sm:w-auto sm:min-w-[14rem]"
+              className="inline-flex w-full items-center justify-center bg-giee-green px-8 py-4 font-giee-sans text-base font-semibold text-giee-white transition-colors hover:bg-giee-green/90 sm:w-auto sm:min-w-[14rem]"
             >
               Explore the ecosystem
             </a>
             <a
               href="#pillars"
-              className="inline-flex w-full items-center justify-center border-2 border-giee-ink bg-transparent px-8 py-4 font-montserrat text-base font-semibold text-giee-ink transition-colors hover:bg-giee-ink hover:text-giee-paper sm:w-auto sm:min-w-[14rem]"
+              className="inline-flex w-full items-center justify-center border-2 border-giee-ink bg-transparent px-8 py-4 font-giee-sans text-base font-semibold text-giee-ink transition-colors hover:bg-giee-ink hover:text-giee-paper sm:w-auto sm:min-w-[14rem]"
             >
               Our core pillars
             </a>
@@ -125,7 +125,7 @@ export default function GieePage() {
           aria-label="Scroll to overview"
           className="group absolute bottom-6 left-1/2 hidden -translate-x-1/2 flex-col items-center gap-2 text-giee-slate transition-colors hover:text-giee-ink md:flex"
         >
-          <span className="font-montserrat text-[11px] uppercase tracking-[0.25em]">
+          <span className="font-giee-sans text-[11px] uppercase tracking-[0.25em]">
             Scroll
           </span>
           <ChevronDown className="h-5 w-5 animate-bounce" />
@@ -139,7 +139,7 @@ export default function GieePage() {
       >
         <div className="mx-auto max-w-3xl">
           <Eyebrow>Overview</Eyebrow>
-          <p className="mt-8 font-montserrat text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+          <p className="mt-8 font-giee-sans text-lg leading-relaxed text-giee-ink-soft md:text-xl">
             The Global Inclusive Education Ecosystem (GIEE) serves as a
             foundational bridge linking emerging technology with robust
             human-centered frameworks. In direct collaboration with the Global
@@ -147,7 +147,7 @@ export default function GieePage() {
             Forum, we are moving beyond a posture of merely reacting to digital
             shifts.
           </p>
-          <p className="mt-6 font-montserrat text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+          <p className="mt-6 font-giee-sans text-lg leading-relaxed text-giee-ink-soft md:text-xl">
             Together, we are designing the global benchmarks, policies, and
             guardrails that ensure AI serves as an instrument for collective
             empowerment, ethical growth, and educational trust.
@@ -163,7 +163,7 @@ export default function GieePage() {
         <div className="mx-auto max-w-6xl">
           <div className="mx-auto max-w-2xl text-center">
             <Eyebrow>Our Core Pillars of Systemic Governance</Eyebrow>
-            <p className="mt-6 font-montserrat text-lg leading-relaxed text-giee-ink-soft">
+            <p className="mt-6 font-giee-sans text-lg leading-relaxed text-giee-ink-soft">
               When we discuss &ldquo;human-centered design&rdquo; in artificial
               intelligence architecture, it cannot simply be a rhetorical
               catchphrase. True technological equity requires an intentional,
@@ -176,13 +176,13 @@ export default function GieePage() {
             {pillars.map((p, i) => (
               <li key={p.name}>
                 <div className="group flex h-full flex-col border border-giee-line bg-giee-white p-8 transition-all hover:-translate-y-1 hover:border-giee-ink hover:shadow-md">
-                  <span className="font-montserrat text-xs font-semibold tracking-[0.22em] text-giee-accent">
+                  <span className="font-giee-sans text-xs font-semibold tracking-[0.22em] text-giee-accent">
                     0{i + 1}
                   </span>
-                  <h3 className="mt-4 font-dmserif text-2xl leading-snug text-giee-ink md:text-[1.65rem]">
+                  <h3 className="mt-4 font-giee-serif text-2xl leading-snug text-giee-ink md:text-[1.65rem]">
                     {p.name}
                   </h3>
-                  <p className="mt-4 flex-1 font-montserrat text-base leading-relaxed text-giee-ink-soft">
+                  <p className="mt-4 flex-1 font-giee-sans text-base leading-relaxed text-giee-ink-soft">
                     {p.description}
                   </p>
                 </div>
@@ -206,10 +206,10 @@ export default function GieePage() {
             {initiatives.map((item) => (
               <li key={item.name}>
                 <div className="flex h-full flex-col border border-giee-line bg-giee-paper p-8 md:p-10">
-                  <h3 className="font-dmserif text-2xl leading-snug text-giee-ink md:text-3xl">
+                  <h3 className="font-giee-serif text-2xl leading-snug text-giee-ink md:text-3xl">
                     {item.name}
                   </h3>
-                  <p className="mt-5 flex-1 font-montserrat text-base leading-relaxed text-giee-ink-soft md:text-lg">
+                  <p className="mt-5 flex-1 font-giee-sans text-base leading-relaxed text-giee-ink-soft md:text-lg">
                     {item.description}
                   </p>
                 </div>
@@ -225,10 +225,10 @@ export default function GieePage() {
         className="scroll-mt-24 bg-giee-ink px-6 py-24 text-giee-paper md:py-32"
       >
         <div className="mx-auto max-w-3xl text-center">
-          <h2 className="font-dmserif text-3xl leading-snug text-giee-paper md:text-4xl">
+          <h2 className="font-giee-serif text-3xl leading-snug text-giee-paper md:text-4xl">
             Shape the Future of Trust with Us
           </h2>
-          <p className="mt-8 font-montserrat text-lg leading-relaxed text-giee-paper/85 md:text-xl">
+          <p className="mt-8 font-giee-sans text-lg leading-relaxed text-giee-paper/85 md:text-xl">
             The intersection of AI governance and inclusive education is the
             defining policy challenge of our era. Whether you are a scholar,
             practitioner, tech architect, or public servant, your insights are
@@ -237,14 +237,14 @@ export default function GieePage() {
           <div className="mt-12 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
             <Link
               href="/contact"
-              className="inline-flex w-full items-center justify-center gap-2 border-2 border-giee-paper bg-giee-paper px-8 py-4 font-montserrat text-base font-semibold text-giee-ink transition-colors hover:bg-transparent hover:text-giee-paper sm:w-auto"
+              className="inline-flex w-full items-center justify-center gap-2 border-2 border-giee-green bg-giee-green px-8 py-4 font-giee-sans text-base font-semibold text-giee-white transition-colors hover:bg-transparent hover:text-giee-white sm:w-auto"
             >
               Explore Our Research Portfolio
               <ArrowRight className="h-4 w-4" />
             </Link>
             <Link
               href="/contact"
-              className="inline-flex w-full items-center justify-center border-2 border-giee-paper bg-transparent px-8 py-4 font-montserrat text-base font-semibold text-giee-paper transition-colors hover:bg-giee-paper hover:text-giee-ink sm:w-auto"
+              className="inline-flex w-full items-center justify-center border-2 border-giee-paper bg-transparent px-8 py-4 font-giee-sans text-base font-semibold text-giee-paper transition-colors hover:bg-giee-paper hover:text-giee-ink sm:w-auto"
             >
               Partner with GIEE
             </Link>

--- a/pages/giee.tsx
+++ b/pages/giee.tsx
@@ -1,0 +1,256 @@
+import Link from "next/link";
+import GieeLayout from "../components/GieeLayout";
+
+const pillars = [
+  {
+    name: "Technology Must Amplify Human Capability",
+    description:
+      "Systems must serve the individual, not the inverse. We advocate for and audit algorithmic models to ensure they are engineered to elevate human curiosity, critical thinking, and baseline capability—never to diminish, gatekeep, or displace the human architecture of learning.",
+  },
+  {
+    name: "Equity Demands Intentional Design",
+    description:
+      "Societies do not stumble into ethical AI platforms. Responsible deployment requires a deliberate vetting infrastructure that forces technology architects, policymakers, and institutions to audit how a digital tool impacts learner privacy, access, and psychological safety before it scales globally.",
+  },
+  {
+    name: "Trust is our Ultimate Institutional Currency",
+    description:
+      "If educators, students, and community stakeholders do not trust the operational systems they rely on, the innovation inherently fails. By anchoring emerging technology in transparent, rigorous governance models, we effectively turn institutional skepticism into collaborative progress.",
+  },
+];
+
+const initiatives = [
+  {
+    name: "The GOER AI Integrity Badge",
+    description:
+      "Administered by the GOER Board, the AI Integrity Badge represents a critical evolution in educational quality assurance. Far more than a technical validation process, this badge establishes the global baseline for ethical, transparent, and accountable AI integration. By auditing and recognizing technical innovators who meet these stringent criteria, we provide educational systems with verified, safe, and equitable digital tools.",
+  },
+  {
+    name: "The UN-Geneva Forum Alliance",
+    description:
+      "Through our continuous collaboration with the Geneva Forum, GIEE scales localized benchmarks into global policy frameworks. This alliance bridges the gap between grassroots educational technology and high-level international diplomacy, ensuring that global frameworks for digital sovereignty are rooted in data-driven, real-world impact.",
+  },
+];
+
+function Eyebrow({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <h2
+      className={`font-montserrat text-xs font-semibold uppercase tracking-[0.22em] text-giee-accent md:text-sm ${className}`}
+    >
+      {children}
+    </h2>
+  );
+}
+
+function ChevronDown({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+function ArrowRight({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </svg>
+  );
+}
+
+export default function GieePage() {
+  return (
+    <GieeLayout>
+      {/* HERO */}
+      <section className="relative isolate overflow-hidden bg-giee-paper">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-giee-line"
+        />
+        <div className="relative mx-auto flex min-h-[82vh] max-w-5xl flex-col items-center justify-center px-6 pb-28 pt-24 text-center md:pt-32">
+          <h1 className="font-dmserif text-4xl leading-[1.05] text-giee-ink md:text-6xl lg:text-7xl">
+            Global AI Governance &amp;
+            <br />
+            Inclusive Education Ecosystem
+          </h1>
+          <p className="mt-8 max-w-2xl font-montserrat text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+            The rapid ascension of generative artificial intelligence demands a
+            proactive, cross-sector approach to technology governance—one that
+            prioritizes human capability, institutional accountability, and
+            equity.
+          </p>
+          <div className="mt-12 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
+            <a
+              href="#overview"
+              className="inline-flex w-full items-center justify-center bg-giee-ink px-8 py-4 font-montserrat text-base font-semibold text-giee-paper transition-colors hover:bg-giee-black sm:w-auto sm:min-w-[14rem]"
+            >
+              Explore the ecosystem
+            </a>
+            <a
+              href="#pillars"
+              className="inline-flex w-full items-center justify-center border-2 border-giee-ink bg-transparent px-8 py-4 font-montserrat text-base font-semibold text-giee-ink transition-colors hover:bg-giee-ink hover:text-giee-paper sm:w-auto sm:min-w-[14rem]"
+            >
+              Our core pillars
+            </a>
+          </div>
+        </div>
+
+        <a
+          href="#overview"
+          aria-label="Scroll to overview"
+          className="group absolute bottom-6 left-1/2 hidden -translate-x-1/2 flex-col items-center gap-2 text-giee-slate transition-colors hover:text-giee-ink md:flex"
+        >
+          <span className="font-montserrat text-[11px] uppercase tracking-[0.25em]">
+            Scroll
+          </span>
+          <ChevronDown className="h-5 w-5 animate-bounce" />
+        </a>
+      </section>
+
+      {/* OVERVIEW */}
+      <section
+        id="overview"
+        className="scroll-mt-24 bg-giee-white px-6 py-24 md:py-32"
+      >
+        <div className="mx-auto max-w-3xl">
+          <Eyebrow>Overview</Eyebrow>
+          <p className="mt-8 font-montserrat text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+            The Global Inclusive Education Ecosystem (GIEE) serves as a
+            foundational bridge linking emerging technology with robust
+            human-centered frameworks. In direct collaboration with the Global
+            Online Education Regulator (GOER) and the United Nations-Geneva
+            Forum, we are moving beyond a posture of merely reacting to digital
+            shifts.
+          </p>
+          <p className="mt-6 font-montserrat text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+            Together, we are designing the global benchmarks, policies, and
+            guardrails that ensure AI serves as an instrument for collective
+            empowerment, ethical growth, and educational trust.
+          </p>
+        </div>
+      </section>
+
+      {/* PILLARS */}
+      <section
+        id="pillars"
+        className="scroll-mt-24 bg-giee-paper px-6 py-24 md:py-32"
+      >
+        <div className="mx-auto max-w-6xl">
+          <div className="mx-auto max-w-2xl text-center">
+            <Eyebrow>Our Core Pillars of Systemic Governance</Eyebrow>
+            <p className="mt-6 font-montserrat text-lg leading-relaxed text-giee-ink-soft">
+              When we discuss &ldquo;human-centered design&rdquo; in artificial
+              intelligence architecture, it cannot simply be a rhetorical
+              catchphrase. True technological equity requires an intentional,
+              evidence-based framework. Our ecosystem is anchored in three
+              structural truths:
+            </p>
+          </div>
+
+          <ul className="mt-16 grid list-none gap-6 p-0 md:grid-cols-3">
+            {pillars.map((p, i) => (
+              <li key={p.name}>
+                <div className="group flex h-full flex-col border border-giee-line bg-giee-white p-8 transition-all hover:-translate-y-1 hover:border-giee-ink hover:shadow-md">
+                  <span className="font-montserrat text-xs font-semibold tracking-[0.22em] text-giee-accent">
+                    0{i + 1}
+                  </span>
+                  <h3 className="mt-4 font-dmserif text-2xl leading-snug text-giee-ink md:text-[1.65rem]">
+                    {p.name}
+                  </h3>
+                  <p className="mt-4 flex-1 font-montserrat text-base leading-relaxed text-giee-ink-soft">
+                    {p.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* INITIATIVES */}
+      <section
+        id="initiatives"
+        className="scroll-mt-24 bg-giee-white px-6 py-24 md:py-32"
+      >
+        <div className="mx-auto max-w-6xl">
+          <div className="mx-auto max-w-2xl text-center">
+            <Eyebrow>Strategic Global Initiatives &amp; Intersections</Eyebrow>
+          </div>
+
+          <ul className="mt-16 grid list-none gap-6 p-0 md:grid-cols-2">
+            {initiatives.map((item) => (
+              <li key={item.name}>
+                <div className="flex h-full flex-col border border-giee-line bg-giee-paper p-8 md:p-10">
+                  <h3 className="font-dmserif text-2xl leading-snug text-giee-ink md:text-3xl">
+                    {item.name}
+                  </h3>
+                  <p className="mt-5 flex-1 font-montserrat text-base leading-relaxed text-giee-ink-soft md:text-lg">
+                    {item.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section
+        id="engage"
+        className="scroll-mt-24 bg-giee-ink px-6 py-24 text-giee-paper md:py-32"
+      >
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="font-dmserif text-3xl leading-snug text-giee-paper md:text-4xl">
+            Shape the Future of Trust with Us
+          </h2>
+          <p className="mt-8 font-montserrat text-lg leading-relaxed text-giee-paper/85 md:text-xl">
+            The intersection of AI governance and inclusive education is the
+            defining policy challenge of our era. Whether you are a scholar,
+            practitioner, tech architect, or public servant, your insights are
+            vital to constructing these global guardrails.
+          </p>
+          <div className="mt-12 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
+            <Link
+              href="/contact"
+              className="inline-flex w-full items-center justify-center gap-2 border-2 border-giee-paper bg-giee-paper px-8 py-4 font-montserrat text-base font-semibold text-giee-ink transition-colors hover:bg-transparent hover:text-giee-paper sm:w-auto"
+            >
+              Explore Our Research Portfolio
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/contact"
+              className="inline-flex w-full items-center justify-center border-2 border-giee-paper bg-transparent px-8 py-4 font-montserrat text-base font-semibold text-giee-paper transition-colors hover:bg-giee-paper hover:text-giee-ink sm:w-auto"
+            >
+              Partner with GIEE
+            </Link>
+          </div>
+        </div>
+      </section>
+    </GieeLayout>
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -11,16 +11,31 @@ export function proxy(req: NextRequest) {
 
   const { pathname } = req.nextUrl;
   if (pathname === '/glqf' || pathname.startsWith('/glqf/')) {
-    return basicAuth(req);
+    return basicAuth(req, {
+      realm: 'glqf',
+      expectedUser: process.env.GLQF_BASIC_AUTH_USER,
+      expectedPass: process.env.GLQF_BASIC_AUTH_PASS,
+    });
+  }
+  if (pathname === '/giee' || pathname.startsWith('/giee/')) {
+    return basicAuth(req, {
+      realm: 'giee',
+      expectedUser: process.env.GIEE_BASIC_AUTH_USER,
+      expectedPass: process.env.GIEE_BASIC_AUTH_PASS,
+    });
   }
 
   return NextResponse.next();
 }
 
-function basicAuth(req: NextRequest) {
-  const expectedUser = process.env.GLQF_BASIC_AUTH_USER;
-  const expectedPass = process.env.GLQF_BASIC_AUTH_PASS;
-
+function basicAuth(
+  req: NextRequest,
+  { realm, expectedUser, expectedPass }: {
+    realm: string;
+    expectedUser?: string;
+    expectedPass?: string;
+  },
+) {
   if (!expectedUser || !expectedPass) {
     return new NextResponse('Basic auth not configured', { status: 503 });
   }
@@ -38,6 +53,6 @@ function basicAuth(req: NextRequest) {
 
   return new NextResponse('Authentication required', {
     status: 401,
-    headers: { 'WWW-Authenticate': 'Basic realm="glqf"' },
+    headers: { 'WWW-Authenticate': `Basic realm="${realm}"` },
   });
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,7 +57,12 @@ module.exports = {
       fontFamily: {
         montserrat: ['Montserrat'],
         dmserif: ['DM Serif Text'],
-        poppins: ['Poppins']
+        poppins: ['Poppins'],
+        // GIEE Brand Standards — Section 3 Typography Architecture.
+        // Primary titles & identity headers: high-contrast serif (deep blue).
+        'giee-serif': ['Georgia', 'Times New Roman', 'serif'],
+        // Subtitles, callouts, body & taglines: balanced, highly readable sans-serif.
+        'giee-sans': ['Arial', 'Helvetica', 'sans-serif']
       },
       lineHeight: {
         'tight-heading': '1.1',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,6 +32,26 @@ module.exports = {
           accent: '#A8501C',
           white: '#FFFFFF',
           black: '#0A0A0A',
+        },
+        giee: {
+          // Primary palette
+          blue: '#0F3D6E', // Ecosystem Deep Blue — primary type, headings, borders
+          green: '#1B7A4E', // Growth Emerald Green — secondary type, organic, metrics
+          // Secondary accent palette
+          red: '#C41E3A', // Impact Crimson Red — critical governance, short-term milestones
+          amber: '#E08B2D', // Foresight Amber Orange — transitional milestones, focal points
+          gold: '#C9A227', // Horizon Gold — strategic stars, long-term goals
+          cyan: '#1AA3C7', // Clearwater Cyan Blue — data points, system pathways
+          // Working aliases used across the GIEE components
+          ink: '#0F3D6E', // = Ecosystem Deep Blue
+          'ink-soft': '#353A40', // Charcoal — body / narrative prose
+          slate: '#6E7681', // Medium grey — taglines, sub-institutional lockups
+          paper: '#F7F9FB',
+          'paper-2': '#EAF0F4',
+          line: '#E2E6EA', // light grey hair-lines
+          accent: '#1B7A4E', // = Growth Emerald Green (subtitle / callout color)
+          white: '#FFFFFF',
+          black: '#0A0A0A',
         }
       },
       fontFamily: {


### PR DESCRIPTION
## What

Adds the **Global AI Governance & Inclusive Education Ecosystem (GIEE)** section for this incubated SPEC project, plus supporting brand tokens and accessibility tests.

## Changes

- **GIEE page** (`pages/giee.tsx`) and its `GieeLayout` / `GieeNavbar` / `GieeFooter` components, mirroring the existing GLQF page pattern (hero, overview, three core pillars, two strategic initiatives, CTA).
- **GIEE brand color palette** in `tailwind.config.js` — the official GIEE Brand Standards: Ecosystem Deep Blue (primary type/headings/borders), Growth Emerald Green (subtitle callouts), charcoal body text, medium-grey taglines, light-grey hair-lines, plus the secondary accent palette (crimson, amber, gold, cyan).
- **jest-axe accessibility tests** (`__tests__/a11y/accessibility.test.tsx`, `jest.setup.js`) asserting no axe violations on the index, ourTeam, giee, and glqf pages.
- Semantic `h2` GIEE eyebrows and `role="group"` on the GLQF diagram svg.

## Verification

`npm run build`, `npm run lint`, and the a11y suite all pass locally; `/giee` prerenders as a static page.

## Notes

- The page copy matches the supplied source text verbatim.
- The fuller brand application (two-tone wordmark, per-card accent colors from the palette) is still to come.
- PR #171 (noindex for incubating sections) is **stacked on this branch** — once this merges to `main`, #171 should be retargeted back to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)