### PR TITLE
Trim README to getting started, move rest to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+This guide covers development workflows beyond the basic [getting started](./README.md) steps.
+
+## Running tests
+
+Run the test suite with:
+
+```bash
+npm run test
+```
+
+## Running linters
+
+Run ESLint with:
+
+```bash
+npm run lint
+```
+
+To run in CI mode to help debug failing GitHub Actions:
+
+```bash
+CI=true npm run lint
+```
+
+## Environment variables
+
+Copy the sample env file to set up email functionality:
+
+```bash
+cp .env.sample .env.local
+```
+
+Fill in the variables as needed. Beyond the Nodemailer credentials in `.env.sample`, the app also reads:
+
+- `CONTENTFUL_SPACE_ID` / `CONTENTFUL_ACCESS_TOKEN` — Contentful CMS (homepage hero)
+- `GLQF_BASIC_AUTH_USER` / `GLQF_BASIC_AUTH_PASS` — basic-auth gate for `/glqf`
+- `GIEE_BASIC_AUTH_USER` / `GIEE_BASIC_AUTH_PASS` — basic-auth gate for `/giee`
+
+These are all read at **runtime** (by `proxy.ts` and `getServerSideProps`), so in production they must be set on the host (see [Deployment](#deployment)), not baked into the build.
+
+## Deployment
+
+Deployed on **DigitalOcean App Platform** (app `spec-frontend`). The app spec is committed at `.do/deploy-template.yml` (single `server` service, Ubuntu-22 buildpack); the buildpack runs `npm run build` then `npm start`. DigitalOcean redeploys automatically from GitHub — the repo's GitHub Actions (`build.yml`, `lint.yml`) only build and lint, they do **not** deploy.
+
+Production environment variables (Contentful, Nodemailer, and the `GLQF_/GIEE_BASIC_AUTH_*` gates) are managed in the DigitalOcean dashboard:
+
+> App Platform → `spec-frontend` → Settings → `server` component → Environment Variables (mark secrets as encrypted), then redeploy.
+
+If a basic-auth pair is missing, that page returns `503 Basic auth not configured`.

--- a/README.md
+++ b/README.md
@@ -1,66 +1,20 @@
 # SPEC Frontend
 
-Frontend for [specollective.org](specollective.org) powered [Next.js](https://nextjs.org/) and bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+Frontend for [specollective.org](https://specollective.org), powered by [Next.js](https://nextjs.org/) and bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started
 
-Ensure you have NodeJS version v18.8.0 installed. We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage node version.
+Ensure you have Node.js 20.9 or newer installed. We recommend [nvm](https://github.com/nvm-sh/nvm) to manage your Node version.
 
-To start the development environment install the dependencies and run the development server command:
+Install the dependencies and start the development server:
 
 ```bash
 npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3322](http://localhost:3322) with your browser to see the result.
 
-## Running tests
+## Contributing
 
-To run the test suite run 
-
-```
-npm run test
-```
-
-## Running linters
-
-To run ESLINT use the command 
-
-```
-npm run lint
-```
-
-To run in CI mode to help with debugging Github Action failing
-
-```
-CI=true npm run lint
-```
-
-## Updating environment variables
-
-To copy over env variables needed for email functionality
-
-```
-cp .env.sample .env.local
-```
-
-Fill in the variables as needed.
-
-Beyond the Nodemailer credentials in `.env.sample`, the app also reads:
-
-- `CONTENTFUL_SPACE_ID` / `CONTENTFUL_ACCESS_TOKEN` — Contentful CMS (homepage hero)
-- `GLQF_BASIC_AUTH_USER` / `GLQF_BASIC_AUTH_PASS` — basic-auth gate for `/glqf`
-- `GIEE_BASIC_AUTH_USER` / `GIEE_BASIC_AUTH_PASS` — basic-auth gate for `/giee`
-
-These are all read at **runtime** (by `proxy.ts` and `getServerSideProps`), so in production they must be set on the host (see Deployment), not baked into the build.
-
-## Deployment
-
-Deployed on **DigitalOcean App Platform** (app `spec-frontend`). The app spec is committed at `.do/deploy-template.yml` (single `server` service, Ubuntu-22 buildpack); the buildpack runs `npm run build` then `npm start`. DigitalOcean redeploys automatically from GitHub — the repo's GitHub Actions (`build.yml`, `lint.yml`) only build and lint, they do **not** deploy.
-
-Production environment variables (Contentful, Nodemailer, and the `GLQF_/GIEE_BASIC_AUTH_*` gates) are managed in the DigitalOcean dashboard:
-
-> App Platform → `spec-frontend` → Settings → `server` component → Environment Variables (mark secrets as encrypted), then redeploy.
-
-If a basic-auth pair is missing, that page returns `503 Basic auth not configured`.
+For tests, linting, environment variables, and deployment, see [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Splits the README so it stays a lean getting-started, moving everything else into a new `CONTRIBUTING.md`.

- **README.md** — basic getting started only: description, Node prerequisite, `npm install` + `npm run dev`, pointer to CONTRIBUTING.
- **CONTRIBUTING.md** (new) — tests, linting (incl. CI mode), environment variables, and deployment.

## Inaccuracies fixed while reviewing

- Dev server port `3000` → **`3322`** (matches `next dev -p 3322` in `package.json`)
- Node version `v18.8.0` → **`20.9+`** (matches `package.json` `engines`)
- Bare `specollective.org` link → `https://specollective.org`; "powered by Next.js" grammar

## Notes / follow-ups (not in this PR)

- `CLAUDE.md` also references port 3000 — still wrong.
- `.nvmrc` still pins `18.18.2`, below the `>=20.9.0` engines floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)