### PR TITLE
Add GIEE Research and Partner subpages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Copy `.env.sample` to `.env.local` for local dev. The sample only includes Nodem
 - `NEXT_PUBLIC_API_URL` — Optional; overrides contact form API URL (defaults to `http://localhost:3000/api/contact`)
 - `GLQF_BASIC_AUTH_USER` / `GLQF_BASIC_AUTH_PASS` — Basic-auth gate for `/glqf`
 - `GIEE_BASIC_AUTH_USER` / `GIEE_BASIC_AUTH_PASS` — Basic-auth gate for `/giee`
+- `GIEE_INQUIRY_EMAIL` — Optional; recipient for GIEE partner-form submissions (`formType: "giee-partner"`). Falls back to `NODE_MAILER_EMAIL` if unset. Server-side only (not `NEXT_PUBLIC_`)
 
 **Runtime, not build:** every variable above is read at **runtime** — by the `proxy.ts` middleware (basic auth) and `getServerSideProps` (Contentful) — *not* inlined at build time. In production they must be set in the **DigitalOcean App Platform** environment (see Deployment), **not** in GitHub Actions. If a basic-auth pair is unset, that page returns `503 Basic auth not configured`.
 

--- a/components/GieeCommunityBand.tsx
+++ b/components/GieeCommunityBand.tsx
@@ -1,0 +1,63 @@
+// "Join Our GIEE Community" — a reusable call-to-action band rather than a
+// popup/rollover. It surfaces the decentralized working-group invitation at the
+// foot of GIEE subpages so visitors can step into the ecosystem inline.
+
+// TODO: replace with the real GIEE LinkedIn community group URL once it exists.
+const GIEE_LINKEDIN_GROUP_URL = "https://www.linkedin.com/groups/";
+
+function ArrowUpRight({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <line x1="7" y1="17" x2="17" y2="7" />
+      <polyline points="7 7 17 7 17 17" />
+    </svg>
+  );
+}
+
+export default function GieeCommunityBand() {
+  return (
+    <section
+      id="community"
+      className="scroll-mt-24 bg-giee-ink px-6 py-20 text-giee-paper md:py-24"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-10 md:flex-row md:items-center md:justify-between">
+        <div className="max-w-2xl">
+          <h2 className="font-giee-sans text-xs font-semibold uppercase tracking-[0.22em] text-giee-cyan">
+            Join Our GIEE Community
+          </h2>
+          <p className="mt-5 font-giee-serif text-2xl leading-snug text-giee-paper md:text-3xl">
+            Connect with the Ecosystem Architecture
+          </p>
+          <p className="mt-5 font-giee-sans text-base leading-relaxed text-giee-paper/85 md:text-lg">
+            The heartbeat of GIEE relies on our active, decentralized
+            peer-to-peer network. Don&rsquo;t wait for our next formal
+            presentation to step into the ecosystem. Join our official working
+            group right now to interact with our Case Study Leads and
+            participate in public evidence reviews.
+          </p>
+        </div>
+
+        <div className="shrink-0">
+          <a
+            href={GIEE_LINKEDIN_GROUP_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex w-full items-center justify-center gap-2 border-2 border-giee-paper bg-transparent px-8 py-4 font-giee-sans text-base font-semibold text-giee-paper transition-colors hover:bg-giee-paper hover:text-giee-ink sm:w-auto"
+          >
+            Join the GIEE LinkedIn Community Group
+            <ArrowUpRight className="h-4 w-4" />
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/GieeCommunityBand.tsx
+++ b/components/GieeCommunityBand.tsx
@@ -2,8 +2,7 @@
 // popup/rollover. It surfaces the decentralized working-group invitation at the
 // foot of GIEE subpages so visitors can step into the ecosystem inline.
 
-// TODO: replace with the real GIEE LinkedIn community group URL once it exists.
-const GIEE_LINKEDIN_GROUP_URL = "https://www.linkedin.com/groups/";
+const GIEE_LINKEDIN_GROUP_URL = "https://www.linkedin.com/groups/20130046/";
 
 function ArrowUpRight({ className = "" }: { className?: string }) {
   return (

--- a/components/GieeNavbar.tsx
+++ b/components/GieeNavbar.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 const NAV_LINKS = [
   { href: "/giee#overview", label: "Overview" },
   { href: "/giee#pillars", label: "Pillars" },
-  { href: "/giee#initiatives", label: "Initiatives" },
-  { href: "/giee#engage", label: "Get Involved" },
+  { href: "/giee/research", label: "Research" },
+  { href: "/giee/partner", label: "Partner" },
 ];
 
 // Supported languages for the GIEE site. Selection is presentational only for

--- a/components/GieePartnerForm.tsx
+++ b/components/GieePartnerForm.tsx
@@ -43,6 +43,24 @@ const schema = yup.object().shape({
   message: yup.string().required("Required"),
 });
 
+function CheckCircle({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  );
+}
+
 const labelClasses = "font-giee-sans text-sm font-semibold text-giee-ink";
 const baseFieldClasses =
   "rounded-none border bg-giee-white px-4 py-3 font-giee-sans text-base text-giee-ink placeholder:text-giee-slate focus:outline-none focus:border-giee-green focus:ring-1 focus:ring-giee-green";
@@ -63,6 +81,8 @@ export default function GieePartnerForm() {
   ) {
     setFailed(false);
     const payload = {
+      // Routes the email to GIEE_INQUIRY_EMAIL server-side (see api/contact.ts).
+      formType: "giee-partner",
       fullName: values.fullName,
       email: values.email,
       reason: `GIEE Partnership Inquiry — ${values.interest}`,
@@ -88,6 +108,32 @@ ${values.message}`,
     } catch {
       setFailed(true);
     }
+  }
+
+  if (submitted) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex flex-col items-start gap-5 py-6"
+      >
+        <CheckCircle className="h-12 w-12 text-giee-green" />
+        <h3 className="font-giee-serif text-2xl text-giee-ink">
+          Thank you — your inquiry has been sent.
+        </h3>
+        <p className="font-giee-sans text-base leading-relaxed text-giee-ink-soft">
+          Our team will review your message and route it to the right Case Study
+          Lead. We&rsquo;ll be in touch at the email address you provided.
+        </p>
+        <button
+          type="button"
+          onClick={() => setSubmitted(false)}
+          className="inline-flex items-center justify-center border-2 border-giee-green bg-transparent px-6 py-3 font-giee-sans text-base font-semibold text-giee-green transition-colors hover:bg-giee-green hover:text-giee-white"
+        >
+          Submit another inquiry
+        </button>
+      </div>
+    );
   }
 
   return (
@@ -248,11 +294,6 @@ ${values.message}`,
 
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div role="status" aria-live="polite" className="font-giee-sans text-sm">
-              {submitted && (
-                <span className="font-semibold text-giee-green">
-                  Thank you — your partnership inquiry has been sent.
-                </span>
-              )}
               {failed && (
                 <span className="font-semibold text-giee-red">
                   Something went wrong. Please try again.

--- a/components/GieePartnerForm.tsx
+++ b/components/GieePartnerForm.tsx
@@ -5,8 +5,9 @@ import * as yup from "yup";
 // The GIEE intake reuses the existing Nodemailer contact API (no new backend or
 // secret required). The partner-specific fields are composed into the email body
 // and the chosen area of interest is mapped onto the API's `reason` field.
-const API_URL =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api/contact";
+// Relative by default so the POST hits whatever origin served the page (any dev
+// port, the Caddy proxy host, or production) rather than a hardcoded localhost.
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "/api/contact";
 
 const ROLES = [
   "K-12 / Higher Ed",

--- a/components/GieePartnerForm.tsx
+++ b/components/GieePartnerForm.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { Form, Formik, Field } from "formik";
+import * as yup from "yup";
+
+// The GIEE intake reuses the existing Nodemailer contact API (no new backend or
+// secret required). The partner-specific fields are composed into the email body
+// and the chosen area of interest is mapped onto the API's `reason` field.
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api/contact";
+
+const ROLES = [
+  "K-12 / Higher Ed",
+  "Industry / AI Architect",
+  "Non-Profit Lead",
+  "Community Advocate",
+  "Policy Official",
+] as const;
+
+const INTERESTS = [
+  "News",
+  "Case Study Partnership",
+  "Research",
+  "New Proposal",
+  "Other",
+] as const;
+
+interface PartnerInfo {
+  fullName: string;
+  email: string;
+  affiliation: string;
+  role: string;
+  interest: string;
+  message: string;
+}
+
+const schema = yup.object().shape({
+  fullName: yup.string().required("Required"),
+  email: yup.string().email("Enter a valid email address").required("Required"),
+  affiliation: yup.string().required("Required"),
+  role: yup.string().oneOf(ROLES as readonly string[]).required("Required"),
+  interest: yup.string().oneOf(INTERESTS as readonly string[]).required("Required"),
+  message: yup.string().required("Required"),
+});
+
+const labelClasses = "font-giee-sans text-sm font-semibold text-giee-ink";
+const baseFieldClasses =
+  "rounded-none border bg-giee-white px-4 py-3 font-giee-sans text-base text-giee-ink placeholder:text-giee-slate focus:outline-none focus:border-giee-green focus:ring-1 focus:ring-giee-green";
+const errorFieldClasses = "border-giee-red";
+const normalFieldClasses = "border-giee-line";
+
+function fieldClasses(hasError: unknown) {
+  return `${baseFieldClasses} ${hasError ? errorFieldClasses : normalFieldClasses}`;
+}
+
+export default function GieePartnerForm() {
+  const [submitted, setSubmitted] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  async function onSubmit(
+    values: PartnerInfo,
+    { resetForm }: { resetForm: () => void },
+  ) {
+    setFailed(false);
+    const payload = {
+      fullName: values.fullName,
+      email: values.email,
+      reason: `GIEE Partnership Inquiry — ${values.interest}`,
+      message: `Affiliation: ${values.affiliation}
+Primary Professional Role: ${values.role}
+Area of Interest: ${values.interest}
+
+${values.message}`,
+    };
+
+    try {
+      const response = await fetch(API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (response.ok) {
+        setSubmitted(true);
+        resetForm();
+      } else {
+        setFailed(true);
+      }
+    } catch {
+      setFailed(true);
+    }
+  }
+
+  return (
+    <Formik
+      initialValues={{
+        fullName: "",
+        email: "",
+        affiliation: "",
+        role: "",
+        interest: "",
+        message: "",
+      }}
+      validationSchema={schema}
+      onSubmit={onSubmit}
+    >
+      {({ errors, touched }) => (
+        <Form
+          role="form"
+          id="giee-partner-form"
+          className="flex flex-col gap-6"
+          noValidate
+        >
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="fullName" className={labelClasses}>
+                Name <span aria-hidden="true" className="text-giee-red">*</span>
+              </label>
+              <Field
+                id="fullName"
+                name="fullName"
+                type="text"
+                placeholder="First name Last name"
+                autoComplete="name"
+                aria-required="true"
+                className={fieldClasses(errors.fullName && touched.fullName)}
+              />
+              {errors.fullName && touched.fullName && (
+                <div className="font-giee-sans text-sm text-giee-red" role="alert">
+                  {errors.fullName}
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="email" className={labelClasses}>
+                Email <span aria-hidden="true" className="text-giee-red">*</span>
+              </label>
+              <Field
+                id="email"
+                name="email"
+                type="email"
+                placeholder="hello@institution.org"
+                autoComplete="email"
+                aria-required="true"
+                className={fieldClasses(errors.email && touched.email)}
+              />
+              {errors.email && touched.email && (
+                <div className="font-giee-sans text-sm text-giee-red" role="alert">
+                  {errors.email}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="affiliation" className={labelClasses}>
+              Affiliation <span aria-hidden="true" className="text-giee-red">*</span>
+            </label>
+            <Field
+              id="affiliation"
+              name="affiliation"
+              type="text"
+              placeholder="Institution, organization, or company"
+              autoComplete="organization"
+              aria-required="true"
+              className={fieldClasses(errors.affiliation && touched.affiliation)}
+            />
+            {errors.affiliation && touched.affiliation && (
+              <div className="font-giee-sans text-sm text-giee-red" role="alert">
+                {errors.affiliation}
+              </div>
+            )}
+          </div>
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="role" className={labelClasses}>
+                Primary Professional Role{" "}
+                <span aria-hidden="true" className="text-giee-red">*</span>
+              </label>
+              <Field
+                as="select"
+                id="role"
+                name="role"
+                aria-required="true"
+                className={fieldClasses(errors.role && touched.role)}
+              >
+                <option value="">Select a role</option>
+                {ROLES.map((role) => (
+                  <option key={role} value={role}>
+                    {role}
+                  </option>
+                ))}
+              </Field>
+              {errors.role && touched.role && (
+                <div className="font-giee-sans text-sm text-giee-red" role="alert">
+                  {errors.role}
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="interest" className={labelClasses}>
+                Area of Interest{" "}
+                <span aria-hidden="true" className="text-giee-red">*</span>
+              </label>
+              <Field
+                as="select"
+                id="interest"
+                name="interest"
+                aria-required="true"
+                className={fieldClasses(errors.interest && touched.interest)}
+              >
+                <option value="">Select an area</option>
+                {INTERESTS.map((interest) => (
+                  <option key={interest} value={interest}>
+                    {interest}
+                  </option>
+                ))}
+              </Field>
+              {errors.interest && touched.interest && (
+                <div className="font-giee-sans text-sm text-giee-red" role="alert">
+                  {errors.interest}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="message" className={labelClasses}>
+              Message <span aria-hidden="true" className="text-giee-red">*</span>
+            </label>
+            <Field
+              as="textarea"
+              id="message"
+              name="message"
+              rows={6}
+              placeholder="Tell us about your collaboration objectives."
+              aria-required="true"
+              className={`${fieldClasses(errors.message && touched.message)} min-h-32`}
+            />
+            {errors.message && touched.message && (
+              <div className="font-giee-sans text-sm text-giee-red" role="alert">
+                {errors.message}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div role="status" aria-live="polite" className="font-giee-sans text-sm">
+              {submitted && (
+                <span className="font-semibold text-giee-green">
+                  Thank you — your partnership inquiry has been sent.
+                </span>
+              )}
+              {failed && (
+                <span className="font-semibold text-giee-red">
+                  Something went wrong. Please try again.
+                </span>
+              )}
+            </div>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center bg-giee-green px-8 py-4 font-giee-sans text-base font-semibold text-giee-white transition-colors hover:bg-giee-green/90"
+            >
+              Submit Partnership Inquiry
+            </button>
+          </div>
+        </Form>
+      )}
+    </Formik>
+  );
+}

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -8,13 +8,24 @@ export default async function handler (req: NextApiRequest, res: NextApiResponse
   try {
     const { method } = req;
     if (method === "POST") {
+      // GIEE partner inquiries route to a dedicated recipient when configured;
+      // every other form keeps going to the Nodemailer account. The recipient is
+      // chosen server-side from `formType` (never from a client-supplied address)
+      // so the endpoint can't be used as an open relay.
+      const isGiee = body.formType === "giee-partner";
+      const recipient =
+        (isGiee && process.env.GIEE_INQUIRY_EMAIL) ||
+        `${process.env.NODE_MAILER_EMAIL}`;
+      const subject = isGiee
+        ? "GIEE Partnership Inquiry"
+        : "Website Contact Form Submission";
       // Do something for POST requests
       await sendMail(
-        "Website Contact Form Submission",
-        `${process.env.NODE_MAILER_EMAIL}`,
-        `Name: ${body.fullName} 
-Email: ${body.email}  
-Reason: ${body.reason} 
+        subject,
+        recipient,
+        `Name: ${body.fullName}
+Email: ${body.email}
+Reason: ${body.reason}
 Message: ${body.message}`
       );
       res.status(201).json({

--- a/pages/giee.tsx
+++ b/pages/giee.tsx
@@ -236,14 +236,14 @@ export default function GieePage() {
           </p>
           <div className="mt-12 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
             <Link
-              href="/contact"
+              href="/giee/research"
               className="inline-flex w-full items-center justify-center gap-2 border-2 border-giee-green bg-giee-green px-8 py-4 font-giee-sans text-base font-semibold text-giee-white transition-colors hover:bg-transparent hover:text-giee-white sm:w-auto"
             >
               Explore Our Research Portfolio
               <ArrowRight className="h-4 w-4" />
             </Link>
             <Link
-              href="/contact"
+              href="/giee/partner"
               className="inline-flex w-full items-center justify-center border-2 border-giee-paper bg-transparent px-8 py-4 font-giee-sans text-base font-semibold text-giee-paper transition-colors hover:bg-giee-paper hover:text-giee-ink sm:w-auto"
             >
               Partner with GIEE

--- a/pages/giee/partner.tsx
+++ b/pages/giee/partner.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import GieeLayout from "../../components/GieeLayout";
+import GieePartnerForm from "../../components/GieePartnerForm";
+import GieeCommunityBand from "../../components/GieeCommunityBand";
+
+export default function GieePartnerPage() {
+  return (
+    <GieeLayout>
+      <section className="bg-giee-paper px-6 pb-20 pt-20 md:pb-28 md:pt-28">
+        <div className="mx-auto max-w-6xl">
+          <Link
+            href="/giee"
+            className="font-giee-sans text-sm text-giee-slate transition-colors hover:text-giee-ink"
+          >
+            ← Back to GIEE
+          </Link>
+
+          <div className="mt-8 grid gap-12 lg:grid-cols-2 lg:gap-16">
+            {/* LEFT — content */}
+            <div className="lg:pr-4">
+              <p className="font-giee-sans text-xs font-semibold uppercase tracking-[0.22em] text-giee-accent md:text-sm">
+                Partner with GIEE
+              </p>
+              <h1 className="mt-6 font-giee-serif text-4xl leading-[1.08] text-giee-ink md:text-5xl">
+                Join the Sandbox
+              </h1>
+              <p className="mt-8 font-giee-sans text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+                GIEE partners with forward-thinking institutions, community
+                advocates, and industry leaders to build bankable,
+                human-centered public assets. Please fill out the form to
+                connect with our Executive Leadership Team.
+              </p>
+
+              <dl className="mt-12 flex flex-col gap-8 border-t border-giee-line pt-10">
+                <div>
+                  <dt className="font-giee-serif text-xl text-giee-ink">
+                    A quality-assured regulatory sandbox
+                  </dt>
+                  <dd className="mt-2 font-giee-sans text-base leading-relaxed text-giee-ink-soft">
+                    We bridge high-level international policy with real-world,
+                    grassroots execution—anchored in the GLQF and GOER
+                    principles.
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-giee-serif text-xl text-giee-ink">
+                    Built for collaboration
+                  </dt>
+                  <dd className="mt-2 font-giee-sans text-base leading-relaxed text-giee-ink-soft">
+                    Whether you arrive with a case study, a new proposal, or a
+                    research question, our team will route your inquiry to the
+                    right Case Study Lead.
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-giee-serif text-xl text-giee-ink">
+                    Explore the portfolio first
+                  </dt>
+                  <dd className="mt-2 font-giee-sans text-base leading-relaxed text-giee-ink-soft">
+                    See our active case studies and ecosystem partners on the{" "}
+                    <Link
+                      href="/giee/research"
+                      className="font-semibold text-giee-green underline-offset-2 hover:underline"
+                    >
+                      Research Portfolio
+                    </Link>
+                    .
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            {/* RIGHT — form */}
+            <div className="border border-giee-line bg-giee-white p-6 md:p-10">
+              <GieePartnerForm />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <GieeCommunityBand />
+    </GieeLayout>
+  );
+}

--- a/pages/giee/research.tsx
+++ b/pages/giee/research.tsx
@@ -1,0 +1,157 @@
+import Link from "next/link";
+import GieeLayout from "../../components/GieeLayout";
+import GieeCommunityBand from "../../components/GieeCommunityBand";
+
+interface Initiative {
+  name: string;
+  description: string;
+  partners: string[];
+}
+
+const initiatives: Initiative[] = [
+  {
+    name: "Women in AI Framework",
+    description:
+      "This initiative explores the structural inclusion of women's perspectives across the entire AI development lifecycle.",
+    partners: [
+      "Mount Saint Mary's University (Los Angeles, CA)",
+      "University of Barcelona — Social Work Department",
+    ],
+  },
+  {
+    name: "Insight Recognition",
+    description:
+      "An AI-driven assessment and personalized learning environment that maps knowledge through individualized, bottom-up concept mapping.",
+    partners: [
+      "Prior Learning Assessment Advisory Group",
+      "United States Workforce Development Partners",
+      "International Educational Systems",
+    ],
+  },
+  {
+    name: "Scaling & Expanding Youth-Led Critical AI Education",
+    description:
+      "A critical science and technology program addressing professional development for K-12 educators regarding sociotechnical harms.",
+    partners: [
+      "UCLA",
+      "Race, Abolition, and Artificial Intelligence (RAAI) Program",
+      "Brown University",
+      "NYC WorkEd",
+    ],
+  },
+  {
+    name: "murmur: AI Design in Mental Health",
+    description:
+      "A structured clinical instrument built on Schema Therapy models to provide clinician-supervised reflective support for learners.",
+    partners: [
+      "APA Professional Networks",
+      "Central Asian University Counseling Centers",
+      "Kyrgyzstan Local Clinicians",
+    ],
+  },
+  {
+    name: "Street Racket: Schools and Hybrid Learning Environments",
+    description:
+      "Investigating how movement-based learning can be enhanced through AI-supported reflection and goal-setting.",
+    partners: [
+      "Street Racket International",
+      "Tarek's Tennis Academy (Belgium)",
+      "Global Educational Technology Partners",
+    ],
+  },
+  {
+    name: "CheckIT Learning: AI Supporting SEN Students",
+    description:
+      "Exploring how neuroscience-informed digital pathways enhance engagement for students with Special Educational Needs (SEN).",
+    partners: [
+      "CheckIT Learning (CLEO LMS Platform)",
+      "St. George's British International School (Bilbao, Spain)",
+    ],
+  },
+];
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="font-giee-sans text-xs font-semibold uppercase tracking-[0.22em] text-giee-accent md:text-sm">
+      {children}
+    </p>
+  );
+}
+
+export default function GieeResearchPage() {
+  return (
+    <GieeLayout>
+      {/* INTRO */}
+      <section className="bg-giee-paper px-6 pb-16 pt-20 md:pb-20 md:pt-28">
+        <div className="mx-auto max-w-4xl">
+          <Link
+            href="/giee"
+            className="font-giee-sans text-sm text-giee-slate transition-colors hover:text-giee-ink"
+          >
+            ← Back to GIEE
+          </Link>
+          <h1 className="mt-6 font-giee-serif text-4xl leading-[1.08] text-giee-ink md:text-5xl lg:text-6xl">
+            Explore Our Research Portfolio
+          </h1>
+          <p className="mt-8 font-giee-sans text-lg leading-relaxed text-giee-ink-soft md:text-xl">
+            Welcome to the Global Inclusive Education Ecosystem (GIEE) Research
+            Portfolio. GIEE functions as a quality-assured regulatory sandbox,
+            bridging high-level international policy with real-world, grassroots
+            execution. By centering our initiatives around the GLQF and GOER
+            principles, we actively shift global education from standard content
+            delivery to outcome-based competency and human-AI synergy.
+          </p>
+        </div>
+      </section>
+
+      {/* PORTFOLIO GRID */}
+      <section className="bg-giee-white px-6 py-20 md:py-28">
+        <div className="mx-auto max-w-6xl">
+          <Eyebrow>Active Case Studies &amp; Ecosystem Partners</Eyebrow>
+
+          <ul className="mt-12 grid list-none gap-6 p-0 md:grid-cols-2 lg:grid-cols-3">
+            {initiatives.map((item) => (
+              <li key={item.name} className="h-full">
+                <article className="flex h-full flex-col border border-giee-line bg-giee-paper p-8 transition-all hover:-translate-y-1 hover:border-giee-ink hover:shadow-md">
+                  <h2 className="font-giee-serif text-2xl leading-snug text-giee-ink">
+                    {item.name}
+                  </h2>
+                  <p className="mt-4 font-giee-sans text-base leading-relaxed text-giee-ink-soft">
+                    {item.description}
+                  </p>
+
+                  <div className="mt-6 border-t border-giee-line pt-5">
+                    <p className="font-giee-sans text-xs font-semibold uppercase tracking-[0.18em] text-giee-accent">
+                      Ecosystem Partners
+                    </p>
+                    <ul className="mt-3 flex list-none flex-col gap-2 p-0">
+                      {item.partners.map((partner) => (
+                        <li
+                          key={partner}
+                          className="font-giee-sans text-sm leading-relaxed text-giee-slate"
+                        >
+                          {partner}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </article>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-16 text-center">
+            <Link
+              href="/giee/partner"
+              className="inline-flex items-center justify-center bg-giee-green px-8 py-4 font-giee-sans text-base font-semibold text-giee-white transition-colors hover:bg-giee-green/90"
+            >
+              Partner with GIEE
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <GieeCommunityBand />
+    </GieeLayout>
+  );
+}


### PR DESCRIPTION
## Summary

Splits the GIEE single-page anchors (Initiatives / Get Involved) into two dedicated, gated subpages and wires up navigation to match.

- **`/giee/research`** — Research Portfolio page listing active case studies and their ecosystem partners.
- **`/giee/partner`** — Partner intake page with a Formik + Yup form. It reuses the existing Nodemailer contact API (no new backend), mapping the partner-specific fields onto the API's `reason`/`message` fields. On success the form is replaced by a clear confirmation panel (with a "Submit another inquiry" reset).
- **`GieeCommunityBand`** — reusable CTA band inviting visitors into the decentralized working group (links to the GIEE LinkedIn group).
- **Navbar + landing CTAs** updated: nav links now point to `/giee/research` and `/giee/partner`; the two landing-page buttons ("Explore Our Research Portfolio" / "Partner with GIEE") point at the new routes instead of `/contact`.

## Email routing

- GIEE partner inquiries send to a dedicated recipient (`GIEE_INQUIRY_EMAIL`) when set, chosen **server-side** from a `formType` flag so the endpoint can't be used as an open relay. Falls back to `NODE_MAILER_EMAIL` if unset. The site contact form is unchanged.
- **New env var to set in production** (DigitalOcean dashboard → `spec-frontend` → `server` → Environment Variables): `GIEE_INQUIRY_EMAIL`. Documented in `CLAUDE.md`.

## Notes

- Both new routes live under `/giee/*`, so they're already covered by the existing basic-auth gate in `proxy.ts`.
- The partner form posts to a relative `/api/contact` URL, so it targets whatever origin serves the page (any dev port, the proxy host, or production) rather than a hardcoded `localhost`.
- `npm run lint` and `tsc --noEmit` pass (only the pre-existing `eslint.config.mjs` warning remains).